### PR TITLE
Make extraction of the tar prefix directory dynamic and configurable

### DIFF
--- a/lib/file-dependencies.rb
+++ b/lib/file-dependencies.rb
@@ -12,7 +12,7 @@ module FileDependencies
       file_list = JSON.load(vendor_file_content)
       FileDependencies.process_downloads(file_list, ::File.join(dir, target), tmpdir)
     else
-      puts "vendor.json not found, looked for the file at #{vendor_file}"
+      puts "vendor.json not found, looked for the file at #{vendor_file}" if $DEBUG
     end
   end # def process_vendor
   module_function :process_vendor
@@ -23,8 +23,8 @@ module FileDependencies
       full_target = file['target'] ? ::File.join(target, file['target']) : target
       download = FileDependencies::File.fetch_file(file['url'], file['sha1'], tmpdir)
       if (res = download.match(/(\S+?)(\.tar\.gz|\.tgz)$/))
-        prefix = res.captures.first.gsub("#{tmpdir}/", '')
         FileDependencies::Archive.untar(download) do |entry|
+          prefix = file['include_tar_prefix'] ? '' : ::File.join(entry.full_name.split("/").first, '')
           next unless FileDependencies::Archive.extract_file?(entry.full_name, file['extract'], file['exclude'], prefix)
           if file['flatten'] == true
             ::File.join(full_target, entry.full_name.split("/").last)

--- a/lib/file-dependencies.rb
+++ b/lib/file-dependencies.rb
@@ -27,7 +27,7 @@ module FileDependencies
           prefix = file['include_tar_prefix'] ? '' : ::File.join(entry.full_name.split(::File::SEPARATOR).first, '')
           next unless FileDependencies::Archive.extract_file?(entry.full_name, file['extract'], file['exclude'], prefix)
           if file['flatten'] == true
-            ::File.join(full_target, entry.full_name.split(::File::SEPARATOR).last)
+            ::File.join(full_target, ::File.basename(entry.full_name))
           else
             ::File.join(full_target, entry.full_name.gsub(prefix, ''))
           end
@@ -35,7 +35,7 @@ module FileDependencies
       elsif download =~ /.gz$/
         FileDependencies::Archive.ungzip(download, full_target)
       else
-        FileUtils.mv(download, ::File.join(full_target, download.split(::File::SEPARATOR).last))
+        FileUtils.mv(download, ::File.join(full_target, ::File.basename(download)))
       end
     end
   end # def download

--- a/lib/file-dependencies.rb
+++ b/lib/file-dependencies.rb
@@ -24,10 +24,10 @@ module FileDependencies
       download = FileDependencies::File.fetch_file(file['url'], file['sha1'], tmpdir)
       if (res = download.match(/(\S+?)(\.tar\.gz|\.tgz)$/))
         FileDependencies::Archive.untar(download) do |entry|
-          prefix = file['include_tar_prefix'] ? '' : ::File.join(entry.full_name.split("/").first, '')
+          prefix = file['include_tar_prefix'] ? '' : ::File.join(entry.full_name.split(::File::SEPARATOR).first, '')
           next unless FileDependencies::Archive.extract_file?(entry.full_name, file['extract'], file['exclude'], prefix)
           if file['flatten'] == true
-            ::File.join(full_target, entry.full_name.split("/").last)
+            ::File.join(full_target, entry.full_name.split(::File::SEPARATOR).last)
           else
             ::File.join(full_target, entry.full_name.gsub(prefix, ''))
           end
@@ -35,7 +35,7 @@ module FileDependencies
       elsif download =~ /.gz$/
         FileDependencies::Archive.ungzip(download, full_target)
       else
-        FileUtils.mv(download, ::File.join(full_target, download.split("/").last))
+        FileUtils.mv(download, ::File.join(full_target, download.split(::File::SEPARATOR).last))
       end
     end
   end # def download

--- a/lib/file-dependencies/archive.rb
+++ b/lib/file-dependencies/archive.rb
@@ -5,7 +5,7 @@ module FileDependencies
   # :nodoc:
   module Archive
     def ungzip(file, outdir)
-      output = ::File.join(outdir, file.gsub('.gz', '').split("/").last)
+      output = ::File.join(outdir, file.gsub('.gz', '').split(::File::SEPARATOR).last)
       tgz = Zlib::GzipReader.new(::File.open(file))
       begin
         ::File.open(output, "w") do |out|

--- a/spec/file-dependencies_spec.rb
+++ b/spec/file-dependencies_spec.rb
@@ -15,11 +15,11 @@ describe FileDependencies do
     let(:tmpdir) { Stud::Temporary.directory }
     let(:target) { Stud::Temporary.directory }
 
-    let(:file1) { Assist.generate_tarball('some/file' => 'content1', 'some/other/file' => 'content2', 'other' => 'content3') }
+    let(:file1) { Assist.generate_tarball('somefile1/some/file' => 'content1', 'somefile1/some/other/file' => 'content2', 'somefile1/other' => 'content3') }
     let(:file2) { Assist.generate_file('some_content') }
     let(:file3) { Assist.generate_gzip('some_content_for_gzip') }
     let(:file4) { Assist.generate_tarball('jars/some.jar' => 'content10', 'jars/someother.jar' => 'content11', 'somefile.txt' => 'bla') }
-    let(:file5) { Assist.generate_tarball('src/types.db' => 'typesdb') }
+    let(:file5) { Assist.generate_tarball('mytarball/src/types.db' => 'typesdb') }
 
     let(:sha1) { FileDependencies::File.calculate_sha1(file1) }
     let(:sha2) { FileDependencies::File.calculate_sha1(file2) }
@@ -35,7 +35,7 @@ describe FileDependencies do
 
     let(:entries) { ['somefile2.txt', 'somefile3', 'some/file', 'some/other/file', 'other', 'jarfiles/jars/some.jar', 'jarfiles/jars/someother.jar', 'jarfiles/somefile.txt', 'types.db'] }
 
-    let(:files) { [{ 'url' => url1, 'sha1' => sha1 }, { 'url' => url2, 'sha1' => sha2 }, { 'url' => url3, 'sha1' => sha3 }, { 'url' => url4, 'sha1' => sha4, 'extract' => [/\.jar/, /\.txt/], 'target' => 'jarfiles' }, { 'url' => url5, 'sha1' => sha5, 'flatten' => true }] }
+    let(:files) { [{ 'url' => url1, 'sha1' => sha1 }, { 'url' => url2, 'sha1' => sha2 }, { 'url' => url3, 'sha1' => sha3 }, { 'url' => url4, 'sha1' => sha4, 'extract' => [/\.jar/, /\.txt/], 'target' => 'jarfiles', 'include_tar_prefix' => true }, { 'url' => url5, 'sha1' => sha5, 'flatten' => true }] }
 
     it 'processes file list' do
       stub_request(:get, url1).to_return(:body => File.new(file1), :status => 200)
@@ -65,11 +65,11 @@ describe FileDependencies do
     let(:tmpdir) { Stud::Temporary.directory }
     let(:target) { Stud::Temporary.directory }
 
-    let(:file1) { Assist.generate_tarball('some/file' => 'content1', 'some/other/file' => 'content2', 'other' => 'content3') }
+    let(:file1) { Assist.generate_tarball('somefile1/some/file' => 'content1', 'somefile1/some/other/file' => 'content2', 'somefile1/other' => 'content3') }
     let(:file2) { Assist.generate_file('some_content') }
     let(:file3) { Assist.generate_gzip('some_content_for_gzip') }
     let(:file4) { Assist.generate_tarball('jars/some.jar' => 'content10', 'jars/someother.jar' => 'content11', 'somefile.txt' => 'bla') }
-    let(:file5) { Assist.generate_tarball('src/types.db' => 'typesdb') }
+    let(:file5) { Assist.generate_tarball('mytarball/src/types.db' => 'typesdb') }
 
     let(:sha1) { FileDependencies::File.calculate_sha1(file1) }
     let(:sha2) { FileDependencies::File.calculate_sha1(file2) }
@@ -83,7 +83,7 @@ describe FileDependencies do
     let(:url4) { 'http://www.example.com/somefile4.tar.gz' }
     let(:url5) { 'http://www.example.com/somefile5.tar.gz' }
 
-    let(:files) { [{ 'url' => url1, 'sha1' => sha1 }, { 'url' => url2, 'sha1' => sha2 }, { 'url' => url3, 'sha1' => sha3 }, { 'url' => url4, 'sha1' => sha4, 'extract' => [/\.jar/, /\.txt/], 'target' => 'jarfiles' }, { 'url' => url5, 'sha1' => sha5, 'flatten' => true }].to_json }
+    let(:files) { [{ 'url' => url1, 'sha1' => sha1 }, { 'url' => url2, 'sha1' => sha2 }, { 'url' => url3, 'sha1' => sha3 }, { 'url' => url4, 'sha1' => sha4, 'extract' => [/\.jar/, /\.txt/], 'target' => 'jarfiles', 'include_tar_prefix' => true }, { 'url' => url5, 'sha1' => sha5, 'flatten' => true }].to_json }
 
     let(:vendorfile) { File.write(File.join(target, 'vendor.json'), files) }
     let(:entries) { ['somefile2.txt', 'somefile3', 'some/file', 'some/other/file', 'other', 'jarfiles/jars/some.jar', 'jarfiles/jars/someother.jar', 'jarfiles/somefile.txt', 'types.db'] }


### PR DESCRIPTION
Previously i assumed that the filename would be same as the prefix directory in the tarballs.
In some cases that is not true so now made it auto detecting that.
Also added an option to include the tar prefix directory in extraction.