### PR TITLE
Fix/windows path

### DIFF
--- a/lib/file-dependencies/file.rb
+++ b/lib/file-dependencies/file.rb
@@ -46,7 +46,7 @@ module FileDependencies
 
     def download(url, target)
       uri = URI(url)
-      output = "#{target}/#{::File.basename(uri.path)}"
+      output = ::File.join(target, ::File.basename(uri.path))
       tmp = "#{output}.tmp"
       Net::HTTP.start(uri.host, uri.port, :use_ssl => (uri.scheme == "https")) do |http|
         request = Net::HTTP::Get.new(uri.path)

--- a/lib/file-dependencies/version.rb
+++ b/lib/file-dependencies/version.rb
@@ -1,5 +1,5 @@
 # Note to authors: this should not include dashes because 'gem' barfs if
 # you include a dash in the version string.
 module FileDependencies
-  VERSION = '0.1.4'
+  VERSION = '0.1.5'
 end


### PR DESCRIPTION
Use the `File.join` to generate the destination, the path on windows was causing a sha1 mismatch.
I have bumped the version!